### PR TITLE
Added RAML API doc hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ The integration test provided currently does only the following:
 `http://localhost:4560/swagger`
 
 See the PersonResource class for information on how to annotate the methods so they are displayed in the documentation.
+
+[RAML](http://raml.org) API documentation is also hosted inside the sample-service, available on the following path:
+`http://localhost:4560/api`
+
+The RAML API documentation is generated from a RAML API specification file, `apispec.raml`, in the root of the project directory.

--- a/apispec.raml
+++ b/apispec.raml
@@ -1,0 +1,44 @@
+#%RAML 0.8
+title: Sample Dropwizard Service RAML API specification
+version: v1.3.3.7
+baseUri: https://api.sample.com
+/people:
+  description: Person collection
+  get:
+    description: Get a list of stored people
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              [
+                {
+                  "id": 1,
+                  "name": "John Smith"
+                },
+                {
+                  "id": 2,
+                  "name": "Jane Doe"
+                }
+              ]
+  /{id}:
+    description: Person entities
+    get:
+      description: Get a stored person
+      responses:
+        200:
+          body:
+            application/json:
+              example: |
+                {
+                  "id": 2,
+                  "name": "Jane Doe"
+                }
+        404:
+          body:
+            application/json:
+              example: |
+                {
+                  "code": 404,
+                  "message": "HTTP 404 Not Found"
+                }

--- a/sample-service/build.gradle
+++ b/sample-service/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile (
         'io.dropwizard:dropwizard-core:' + dropwizardVersion,
         'com.smoketurner:dropwizard-swagger:1.0.0-1',
+        'net.ozwolf:dropwizard-raml-view:1.0.0.1',
         project(':sample-api')
     )
     testCompile (

--- a/sample-service/src/main/java/com/sample/PersonResponseMapper.java
+++ b/sample-service/src/main/java/com/sample/PersonResponseMapper.java
@@ -1,4 +1,0 @@
-package com.sample;
-
-public class PersonResponseMapper {
-}

--- a/sample-service/src/main/java/com/sample/SampleApplication.java
+++ b/sample-service/src/main/java/com/sample/SampleApplication.java
@@ -10,6 +10,8 @@ import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 
+import net.ozwolf.raml.RamlView;
+
 public class SampleApplication extends Application<SampleConfiguration> {
     public static void main(String[] args) throws Exception {
         new SampleApplication().run(args);
@@ -28,6 +30,7 @@ public class SampleApplication extends Application<SampleConfiguration> {
                 return configuration.swaggerBundleConfiguration;
             }
         });
+        bootstrap.addBundle(RamlView.bundle("apispec.raml"));
     }
 
     @Override

--- a/sample-service/src/main/java/com/sample/resource/PersonResource.java
+++ b/sample-service/src/main/java/com/sample/resource/PersonResource.java
@@ -21,7 +21,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 
 @Path("/people")
-@Api("Sample Dropwizard Service")
+@Api("Sample Dropwizard Service Swagger API annotations")
 @Produces({MediaType.APPLICATION_JSON})
 public class PersonResource {
     private final static Logger LOGGER = LoggerFactory.getLogger(PersonResource.class);


### PR DESCRIPTION
After @OzWolf kindly accepted the pull request https://github.com/ozwolf-software/dropwizard-raml-view/pull/10 to bring the Dropwizard RAML viewer up to supporting Dropwizard 1.0.0 we can bring that in to host RAML documentation as an alternative to using Swagger inline annotations for documentation.
